### PR TITLE
add support for seconds

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,7 +32,7 @@ function App() {
     F: ["Long Date/Time", "LLLL"],
   };
 
-  const [date, setDate] = useState<Dayjs | null>(dayjs());
+  const [date, setDate] = useState<Dayjs | null>(dayjs().set("seconds", 0));
 
   const discordFormat = (key: string) => {
     return `<t:${date!.unix()}:${key}>`;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -83,6 +83,8 @@ function App() {
           </Grid>
           <Grid item>
             <TimePicker
+              inputFormat="LTS"
+              views={["hours", "minutes", "seconds"]}
               renderInput={(props) => <TextField {...props} />}
               label="Time"
               value={date}


### PR DESCRIPTION
I've used this tool a lot, the only thing that really bugged me was my OCD telling me "this isn't exactly 04.30 PM, this is 04.30.xx PM". I've had to manually edit the timestamp so it's exactly 0 seconds, just to satisfy my OCD.

I hope I'm not the only one having the same issue? 😅

Anyway, this PR will just set the default date's seconds to 0, as well as allow the user to pick the amount of seconds they want in their timestamp if they really need to.

This PR is out of nowhere really so I don't mind if you don't feel like this is the right solution to the problem, if it even is a problem at all. Still a great tool that I'll continue using regardless of this PR though.